### PR TITLE
Account for negative values in reading sensor properties.

### DIFF
--- a/Sources/MPU-6050.swift
+++ b/Sources/MPU-6050.swift
@@ -38,19 +38,31 @@ public class MPU6050{
     public var AccelX: Int {
         var rv = UInt16(i2c.readByte(address, command: 0x3B)) << 8
         rv |= UInt16(i2c.readByte(address, command: 0x3C))  
-        return Int(rv)
+        if (rv >= 0x8000) {
+            return -(Int((65535 - rv) + 1))
+        } else {
+            return Int(rv)
+        }
     }
 
     public var AccelY: Int {
         var rv = UInt16(i2c.readByte(address, command: 0x3D)) << 8
         rv |= UInt16(i2c.readByte(address, command: 0x3E))  
-        return Int(rv)
+        if (rv >= 0x8000) {
+            return -(Int((65535 - rv) + 1))
+        } else {
+            return Int(rv)
+        }
     }
 
     public var AccelZ: Int {
         var rv = UInt16(i2c.readByte(address, command: 0x3F)) << 8
         rv |= UInt16(i2c.readByte(address, command: 0x40))     
-        return Int(rv)
+        if (rv >= 0x8000) {
+            return -(Int((65535 - rv) + 1))
+        } else {
+            return Int(rv)
+        }
     }
 
     /// Temperature from -40 to +85 degrees Celsius
@@ -77,19 +89,31 @@ public class MPU6050{
     public var GyroX: Int {
         var rv = UInt16(i2c.readByte(address, command: 0x43)) << 8
         rv |= UInt16(i2c.readByte(address, command: 0x44))     
-        return Int(rv)
+        if (rv >= 0x8000) {
+            return -(Int((65535 - rv) + 1))
+        } else {
+            return Int(rv)
+        }
     }
 
     public var GyroY: Int {
         var rv = UInt16(i2c.readByte(address, command: 0x45)) << 8
         rv |= UInt16(i2c.readByte(address, command: 0x46))  
-        return Int(rv)
+        if (rv >= 0x8000) {
+            return -(Int((65535 - rv) + 1))
+        } else {
+            return Int(rv)
+        }
     }
 
     public var GyroZ: Int {
         var rv = UInt16(i2c.readByte(address, command: 0x47)) << 8
         rv |= UInt16(i2c.readByte(address, command: 0x48))     
-        return Int(rv)
+        if (rv >= 0x8000) {
+            return -(Int((65535 - rv) + 1))
+        } else {
+            return Int(rv)
+        }
     }
 
     public func getAll() -> (AccelX: Int, AccelY: Int, AccelZ: Int, Temp: Float, GyroX: Int, GyroY:Int , GyroZ: Int) {


### PR DESCRIPTION
I believe the current AccelX, AccelY, AccelZ, GyroX, GyroY, and GyroZ properties do not take into account the 2's complement nature of the sensors registers so that human readable conversions can be done for values of g (a?/16384.0) and °/s (g?/131.0).